### PR TITLE
example with gcc

### DIFF
--- a/workflows/README.md
+++ b/workflows/README.md
@@ -3,5 +3,5 @@ Sample CWL workflows
 * [Hello world](hello/README.md)
 * [lobSTR](lobSTR/README)
 * [makefile to CWL](make-to-cwl/README.md)
-
+* [Compile with gcc](compile/README.md)
 

--- a/workflows/compile/README.md
+++ b/workflows/compile/README.md
@@ -1,0 +1,19 @@
+# Compile with GNU GCC
+
+
+## compile1.cwl
+
+compile1.cwl is the CWL equivalent of the following Makefile.
+
+```make
+.PHONY:all
+all:a.out
+a.out: source1.o source2.o
+	gcc -o a.out source1.o source2.o
+source1.o : source1.c source1.h
+	gcc -Wall -c -o source1.o source1.c
+source2.o : source2.c
+	gcc -Wall -c -o source2.o source2.c
+```
+
+it compiles two sources and link them.

--- a/workflows/compile/compile1.cwl
+++ b/workflows/compile/compile1.cwl
@@ -1,0 +1,68 @@
+#!/usr/bin/env cwl-runner
+
+
+- id: "#compile"
+  class: CommandLineTool
+  inputs:
+    - id: "#src"
+      type: File
+      inputBinding: {}
+    - id: "#object"
+      type: string
+      inputBinding:
+          prefix: "-o"
+  outputs:
+    - id: "#compiled"
+      type: File
+      outputBinding:
+          glob:
+             engine: cwl:JsonPointer
+             script: /job/object
+  baseCommand: gcc
+  arguments:
+     - "-c"
+     - "-Wall"
+
+- id: "#link"
+  class: CommandLineTool
+  inputs:
+    - id: "#objects"
+      type:  { type: array, items: File }
+      inputBinding: {}
+    - id: "#output"
+      type: string
+      inputBinding:
+          prefix: "-o"
+  outputs:
+    - id: "#executable"
+      type: File
+      outputBinding:
+          glob:
+             engine: cwl:JsonPointer
+             script: /job/output
+  baseCommand: gcc
+
+
+- id: "#main"
+  class: Workflow
+  inputs: []
+  outputs:
+    - id: "#main.output"
+      type: File
+      source: "#compile.compiled"
+  steps :
+    - id: "#compilesources-src1"
+      run: {import: "#compile"}
+      inputs:
+         - { id: "#compile.src" , default: "source1.c" }
+         - { id: "#compile.object" , default: "source1.o" }
+      outputs:
+        - { id: "#compile.compiled" }
+    - id: "#compilesources-src2"
+      run: {import: "#compile"}
+      inputs:
+         - { id: "#compile.src" , default: "source2.c" }
+         - { id: "#compile.object" , default: "source2.o" }
+      outputs:
+         - { id: "#compile.compiled" }
+

--- a/workflows/compile/source1.c
+++ b/workflows/compile/source1.c
@@ -1,0 +1,3 @@
+#include "source1.h"
+extern int identity(int value);
+int main(void) { return identity(ZERO);}

--- a/workflows/compile/source1.h
+++ b/workflows/compile/source1.h
@@ -1,0 +1,1 @@
+#define ZERO 0

--- a/workflows/compile/source2.c
+++ b/workflows/compile/source2.c
@@ -1,0 +1,1 @@
+int identity(int value) { return value;} 


### PR DESCRIPTION
Hi all,
this is my latest use-case. As a reminder, I'm trying to (automatically) convert a Makefile to CWL.

The makefile would be 

```
.PHONY:all
all:a.out
a.out: source1.o source2.o
	gcc -o a.out source1.o source2.o
source1.o : source1.c source1.h
	gcc -Wall -c -o source1.o source1.c
source2.o : source2.c
	gcc -Wall -c -o source2.o source2.c
```
it compiles two sources and link them . See the code under : https://github.com/lindenb/cwl-workflows/tree/compile/workflows/compile

My current **broken** CWL workflow is here: https://github.com/lindenb/cwl-workflows/tree/compile/workflows/compile

My main problems : 
* the inputs for the "#compile" are existing files, how should I declare them in the step
* I'm puzzled how to declare the final output of my workflow; it should be a **step** specific output id isn't it ? but in https://github.com/common-workflow-language/workflows/blob/master/workflows/hello/hello.cwl  it's the output of a tool.
* there is something wrong in the path, while the makefile above works, the $PATH is 'lost' in cwl-runner and cc1 the subprogram of gcc is not found.
* how should I declare and run the "#link" tool to use both compiled object ?

 Thank you for your help,

Pierre

