### PR TITLE
Add vim temp files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 .vagrant
 .DS_Store
 
+# editor temp files
+.*.sw?
+
 #bioinformatics stuff
 *.bam
 *.bai


### PR DESCRIPTION
This PR does pretty much what it says on the tin. The various `.<FILENAME>.sw[op]` files that vim creates as temp files are now excluded from git.