### PR TITLE
simplify hello.cwl

### DIFF
--- a/workflows/hello/hello.cwl
+++ b/workflows/hello/hello.cwl
@@ -1,15 +1,8 @@
 #!/usr/bin/env cwl-runner
 
-
 - id: "#echocmd"
   class: CommandLineTool
-  inputs:
-    - id: "#echo-in"
-      type: string
-      label: "Message"
-      description: "The message to print"
-      default: "Hello World"
-      inputBinding: {}
+  inputs: []
   outputs:
     - id: "#echo-out"
       type: File
@@ -18,22 +11,7 @@
       outputBinding:
         glob: messageout.txt
   baseCommand: echo
-  stdout: messageout.txt
-
-- id: "#main"
-  class: Workflow
-  label: "Hello World"
-  description: "Puts a message into a file using echo"
-  inputs: []
-  outputs:
-    - id: "#main.output"
-      type: File
-      source: "#echocmd.echo-out"
-  steps :
-    - id: "#step0"
-      run: {import: "#echocmd"}
-      inputs: []
-      outputs:
-        - { id: "#echocmd.echo-out" }
-
-
+  arguments:
+   - Hello
+   - world
+   - "!"


### PR DESCRIPTION
The first encounter with the cwl for executing something needs to be as simple as ... donno ... something really simple.  The traditional "Hello world!" for instance does not need any input. It is a mere generator.

When executing the cwltool, I was asked if I wanted to to run #echocmd or #main. So, if #main is obsolete, which is good, then I strongly suggest not to have it with hello. With a bit of an imagination the CommandLineTool is a special kind of workflow, i.e. one that cannot nest or interconnect other workflows but wraps a tool. Then it is just fine to execute it direcly.

The input line should not be required for a command line. A missing such should just be interpreted as 'no inputs'.

I also removed the "stdout" line to make it more interactive, i.e. just like the original.