### PR TITLE
Move docker import to hints in bwa aln

### DIFF
--- a/tools/bwa-aln.cwl
+++ b/tools/bwa-aln.cwl
@@ -6,8 +6,10 @@ class: CommandLineTool
 
 requirements:
   - $import: envvar-global.yml
-  - $import: bwa-docker.yml
   - class: InlineJavascriptRequirement
+
+hints:
+  - $import: bwa-docker.yml
 
 inputs:
   - id: "prefix"


### PR DESCRIPTION
This change just moves the docker import to the hints section, in the `bwa aln` tool.

Note that this will break stuff because of [this bug in cwltool](https://github.com/common-workflow-language/cwltool/issues/80), so it should probably wait until that is fixed.