### PR TITLE
Add tool wrapper for bwa index

### DIFF
--- a/test/bwa-index-job.json
+++ b/test/bwa-index-job.json
@@ -1,0 +1,9 @@
+{
+  "input":{
+    "path": "test-files/dm3_chr4.fa",
+    "class": "File"
+  },
+  "a": "bwtsw",
+  "b": 1024,
+  "_6": true
+}

--- a/test/bwa-index-test.yaml
+++ b/test/bwa-index-test.yaml
@@ -1,0 +1,13 @@
+- args: [
+    "bwa",
+    "index",
+    "-6",
+    "-a",
+    "bwtsw",
+    "-b",
+    "1024",
+    "./test-files/dm3_chr4.fa",
+  ]
+  job:  bwa-index-job.json
+  tool: ../tools/bwa-index.cwl
+  doc: General test of command line generation

--- a/tools/bwa-index.cwl
+++ b/tools/bwa-index.cwl
@@ -1,0 +1,128 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: "cwl:draft-3"
+
+class: CommandLineTool
+
+requirements:
+  - $import: envvar-global.yml
+  - class: InlineJavascriptRequirement
+
+#TODO: Enable after this issue is fixed: https://github.com/common-workflow-language/cwltool/issues/80
+#hints:
+#  - $import: bwa-docker.yml
+
+inputs:
+  - id: "input"
+    type: File
+    inputBinding:
+      position: 3
+
+  - id: "a"
+    type: ["null", string]
+    description: |
+      BWT construction algorithm: bwtsw or is (Default: auto)
+    inputBinding:
+      position: 2
+      prefix: "-a"
+
+  - id: "p"
+    type: ["null", string]
+    description: |
+      Prefix of the index (Default: same as fasta name)
+    inputBinding:
+      position: 2
+      prefix: "-p"
+
+  - id: "b"
+    type: ["null", int]
+    description: |
+      Block size for the bwtsw algorithm (effective with -a bwtsw) (Default: 10000000)
+    inputBinding:
+      position: 2
+      prefix: "-b"
+
+  - id: "_6"
+    type: ["null", boolean]
+    description: |
+      Index files named as <in.fasta>.64.* instead of <in.fasta>.*
+    inputBinding:
+      position: 2
+      prefix: "-6"
+
+outputs:
+  - id: output
+    type: { type: array, items: File }
+    outputBinding:
+      glob:
+          - ${
+              if (inputs.p) {
+                return inputs.p + ".amb"
+              } else {
+                if (inputs._6 == true) {
+                  return inputs.input.path + ".64.amb"
+                } else {
+                  return inputs.input.path + ".amb"
+                }
+              }
+            }
+          - ${
+              if (inputs.p) {
+                return inputs.p + ".ann"
+              } else {
+                if (inputs._6 == true) {
+                  return inputs.input.path + ".64.ann"
+                } else {
+                  return inputs.input.path + ".ann"
+                }
+              }
+            }
+          - ${
+              if (inputs.p) {
+                return inputs.p + ".bwt"
+              } else {
+                if (inputs._6 == true) {
+                  return inputs.input.path + ".64.bwt"
+                } else {
+                  return inputs.input.path + ".bwt"
+                }
+              }
+            }
+          - ${
+              if (inputs.p) {
+                return inputs.p + ".pac"
+              } else {
+                if (inputs._6 == true) {
+                  return inputs.input.path + ".64.pac"
+                } else {
+                  return inputs.input.path + ".pac"
+                }
+              }
+            }
+          - ${
+              if (inputs.p) {
+                return inputs.p + ".sa"
+              } else {
+                if (inputs._6 == true) {
+                  return inputs.input.path + ".64.sa"
+                } else {
+                  return inputs.input.path + ".sa"
+                }
+              }
+            }
+
+baseCommand:
+  - bwa
+  - index
+
+description: |
+  Usage:   bwa index [options] <in.fasta>
+
+  Options: -a STR    BWT construction algorithm: bwtsw or is [auto]
+           -p STR    prefix of the index [same as fasta name]
+           -b INT    block size for the bwtsw algorithm (effective with -a bwtsw) [10000000]
+           -6        index files named as <in.fasta>.64.* instead of <in.fasta>.*
+
+  Warning: `-a bwtsw' does not work for short genomes, while `-a is' and
+           `-a div' do not work not for long genomes.
+


### PR DESCRIPTION
This adds a wrapper for the `bwa index` subtool of bwa.

Docker support is not added as of yet, since [cwltool#80](github.com/common-workflow-language/cwltool#80) is quite much blocking it, but a TODO with the outcommented lines for that is added.