### PR TITLE
SPP tool wrapping the run_spp.R script used in ENCODE

### DIFF
--- a/test/spp-job.json
+++ b/test/spp-job.json
@@ -1,0 +1,6 @@
+{
+  "input_bam":{
+    "path": "test-files/aligned.bam",
+    "class": "File"
+  }
+}

--- a/test/spp-test.yaml
+++ b/test/spp-test.yaml
@@ -1,0 +1,9 @@
+- args: [
+    "run_spp.R",
+    "-out=aligned.spp_cross_corr.txt",
+    "-c=./test-files/aligned.bam",
+    "-rf"
+  ]
+  job:  spp-job.json
+  tool: ../tools/spp.cwl
+  doc: General test of command line generation for spp tool

--- a/tools/spp-docker.yml
+++ b/tools/spp-docker.yml
@@ -1,0 +1,83 @@
+class: DockerRequirement
+dockerPull: dukegcb/spp
+dockerFile: |
+  #################################################################
+  # Dockerfile
+  #
+  # Software:         run_spp.R
+  # Description:      DukeGCB spp image.
+  # Website (1):      https://github.com/hms-dbmi/spp
+  # Website (2):      https://github.com/crazyhottommy/phantompeakqualtools
+  # Provides:         run_spp.R
+  # Base Image:       r-base:latest
+  # Build Cmd:        docker build --rm -t dukegcb/spp .
+  # Pull Cmd:         docker pull dukegcb/spp
+  # Run Cmd:          docker run --rm -it dukegcb/spp
+  #################################################################
+
+  #######################################################################################
+  # IMPORTANT NOTE:
+  # ^^^^^^^^^^^^^^^
+  #   This image wraps the following tools and scripts:
+  #     - samtools v1.3 (https://github.com/samtools/samtools/releases/download/),
+  #     - bitops_1.0.6 (https://cran.r-project.org/src/contrib/bitops_1.0-6.tar.gz) R package,
+  #     - caTools_1.17.1 (https://cran.r-project.org/src/contrib/caTools_1.17.1.tar.gz) R package,
+  #     - spp v1.13 R package (https://github.com/hms-dbmi/spp),
+  #     - run_spp.R v2.0 R script (https://github.com/crazyhottommy/phantompeakqualtools)
+  #
+  #   Only run_spp.R is provided which works for BAM files with and without duplicates
+  #   when using a version of the SPP R package > 1.10.
+  #
+  #######################################################################################
+
+  FROM r-base:latest
+
+  RUN apt-get update && apt-get install -y \
+    libboost-all-dev \
+    curl \
+    build-essential \
+    libncurses-dev \
+    zlib1g-dev \
+    gawk
+
+  # Installs samtools from sources into /opt/
+  ENV SAMTOOLS_RELEASE=1.3
+  ENV SAMTOOLS_URL=https://github.com/samtools/samtools/releases/download/
+  ENV DEST_DIR=/opt/
+
+  # Download Samtools; untar & decompress; remove tr.bz2 file; compile & install samtools; remove unnecessary files
+  RUN curl -SLo ${DEST_DIR}/samtools-${SAMTOOLS_RELEASE}.tar.bz2 ${SAMTOOLS_URL}/${SAMTOOLS_RELEASE}/samtools-${SAMTOOLS_RELEASE}.tar.bz2 && \
+    tar -xf ${DEST_DIR}/samtools-${SAMTOOLS_RELEASE}.tar.bz2 -C ${DEST_DIR} && \
+    rm ${DEST_DIR}/samtools-${SAMTOOLS_RELEASE}.tar.bz2 && \
+    cd ${DEST_DIR}/samtools-${SAMTOOLS_RELEASE} && \
+    ./configure && \
+    make && \
+    make install && \
+    rm -rf ${DEST_DIR}/samtools-${SAMTOOLS_RELEASE}
+
+  ENV SPP_VERSION=1.13
+
+  WORKDIR /usr/local/src/rscripts
+
+  # Download and install SPP and auxiliary R packages; remove unnecessary files
+  RUN printf 'source("https://bioconductor.org/biocLite.R")\nbiocLite("Rsamtools")\n' > install_Rsamtools.R && \
+      Rscript install_Rsamtools.R && \
+      curl -SLo ./spp_${SPP_VERSION}.tar.gz https://github.com/hms-dbmi/spp/archive/${SPP_VERSION}.tar.gz && \
+      curl -SLo ./bitops_1.0-6.tar.gz https://cran.r-project.org/src/contrib/bitops_1.0-6.tar.gz && \
+      curl -SLo ./caTools_1.17.1.tar.gz https://cran.r-project.org/src/contrib/caTools_1.17.1.tar.gz && \
+      R CMD INSTALL bitops_1.0-6.tar.gz && \
+      R CMD INSTALL caTools_1.17.1.tar.gz && \
+      R CMD INSTALL spp_${SPP_VERSION}.tar.gz && \
+      rm -f ./spp_${SPP_VERSION}.tar.gz ./bitops_1.0-6.tar.gz ./caTools_1.17.1.tar.gz ./install_Rsamtools.R
+
+  # Download and install run_spp.R package; remove unnecessary files
+  RUN Rscript install_Rsamtools.R && \
+      curl -SLo ./run_spp.R.origin https://raw.githubusercontent.com/crazyhottommy/phantompeakqualtools/master/run_spp.R && \
+      printf '#!/usr/bin/env Rscript\n' > ./run_spp.R && \
+      cat ./run_spp.R.origin >> ./run_spp.R && \
+      chmod +x run_spp.R && \
+      rm -f ./run_spp.R.origin
+
+  # Add rscripts folder to PATH
+  ENV PATH=/usr/local/src/rscripts:$PATH
+  CMD ["run_spp.R"]

--- a/tools/spp.cwl
+++ b/tools/spp.cwl
@@ -1,0 +1,155 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: "cwl:draft-3"
+
+class: CommandLineTool
+
+requirements:
+  - $import: spp-docker.yml
+  - class: InlineJavascriptRequirement
+
+inputs:
+# ---------------------------------- #
+# ------  MANDATORY ARGUMENTS  ----- #
+# ---------------------------------- #
+  - id: input_bam
+    type: File
+    description: "<ChIP_alignFile>, full path and name (or URL) of tagAlign/BAM file (can be gzipped)(FILE EXTENSION MUST BE tagAlign.gz, tagAlign, bam or bam.gz)"
+    inputBinding:
+      prefix: "-c="
+      separate: false
+# ------------------------------------------ #
+# -- MANDATORY ARGUMENTS FOR PEAK CALLING -- #
+# ------------------------------------------ #
+  - id: control_bam
+    type:
+      - 'null'
+      - File
+    description: "<Input_alignFile>, full path and name (or URL) of tagAlign/BAM file (can be gzipped) (FILE EXTENSION MUST BE tagAlign.gz, tagAlign, bam or bam.gz)"
+    inputBinding:
+      prefix: "-i="
+      separate: false
+# ---------------------------------- #
+# -------  OPTIONAL ARGUMENTS  ----- #
+# ---------------------------------- #
+  - id: nthreads
+    type:
+      - 'null'
+      - int
+    description: "-p=<nodes> , number of parallel processing nodes, default=0"
+    inputBinding:
+      prefix: "-p="
+      separate: false
+  - id: s
+    type:
+      - 'null'
+      - string
+    description: "-s=<min>:<step>:<max> , strand shifts at which cross-correlation is evaluated, default=-500:5:1500"
+    inputBinding:
+      prefix: "-s="
+      separate: false
+  - id: speak
+    type:
+      - 'null'
+      - string
+    description: "-speak=<strPeak>, user-defined cross-correlation peak strandshift"
+    inputBinding:
+      prefix: "-speak="
+      separate: false
+  - id: x
+    type:
+      - 'null'
+      - string
+    description: "-x=<min>:<max>, strand shifts to exclude (This is mainly to avoid region around phantom peak) default=10:(readlen+10)"
+    inputBinding:
+      prefix: "-x="
+      separate: false
+  - id: fdr
+    type:
+      - 'null'
+      - float
+    description: "-fdr=<falseDisoveryRate> , false discovery rate threshold for peak calling"
+    inputBinding:
+      prefix: "-fdr="
+      separate: false
+  - id: npeak
+    type:
+      - 'null'
+      - int
+    description: "-npeak=<numPeaks>, threshold on number of peaks to call"
+    inputBinding:
+      prefix: "-npeak="
+      separate: false
+  - id: filtchr
+    type:
+      - 'null'
+      - string
+    description: "-filtchr=<chrnamePattern> , Pattern to use to remove tags that map to specific chromosomes e.g. _ will remove all tags that map to chromosomes with _ in their name"
+    inputBinding:
+      prefix: "-filtchr="
+      separate: false
+  - id: savp
+    type:
+      - 'null'
+      - boolean
+    description: "save cross-correlation plot"
+    inputBinding:
+      valueFrom: ${ if (self) return "-savp=" + inputs.input_bam.path.replace(/^.*[\\\/]/, "").replace(/\.[^/.]+$/, "") + ".spp_cross_corr.pdf"; return null}
+  - id: savn
+    type:
+      - 'null'
+      - boolean
+    description: "-savn=<narrowpeakfilename> OR -savn NarrowPeak file name (fixed width peaks)"
+    inputBinding:
+      valueFrom: ${ if (self) return "-savn=" + inputs.input_bam.path.replace(/^.*[\\\/]/, "").replace(/\.[^/.]+$/, "") + ".spp.narrowPeak"; return null}
+  - id: savr
+    type:
+      - 'null'
+      - boolean
+    description: "-savr=<regionpeakfilename> OR -savr RegionPeak file name (variable width peaks with regions of enrichment)"
+    inputBinding:
+      valueFrom: ${ if (self) return "-savr=" + inputs.input_bam.path.replace(/^.*[\\\/]/, "").replace(/\.[^/.]+$/, "") + ".spp.regionPeak"; return null}
+  - id: savd
+    type:
+      - 'null'
+      - boolean
+    description: "-savd=<rdatafile> OR -savd, save Rdata file"
+    inputBinding:
+      valueFrom: ${ if (self) return "-savd=" + inputs.input_bam.path.replace(/^.*[\\\/]/, "").replace(/\.[^/.]+$/, "") + ".spp.Rdata"; return null}
+  - id: rf
+    type: boolean
+    default: true
+    description: "overwrite (force remove) output files in case they exist. Default: true"
+    inputBinding:
+      prefix: "-rf"
+
+outputs:
+  - id: output_spp_cross_corr
+    type: File
+    description: "peakshift/phantomPeak results summary file"
+    outputBinding:
+      glob: $(inputs.input_bam.path.replace(/^.*[\\\/]/, "").replace(/\.[^/.]+$/, "") + ".spp_cross_corr.txt")
+  - id: output_spp_cross_corr_plot
+    type: ['null', File]
+    description: "peakshift/phantomPeak results summary plot"
+    outputBinding:
+      glob: $(inputs.input_bam.path.replace(/^.*[\\\/]/, "").replace(/\.[^/.]+$/, "") + ".spp_cross_corr.pdf")
+  - id: output_spp_narrow_peak
+    type: ['null', File]
+    description: "narrowPeak output file"
+    outputBinding:
+      glob: $(inputs.input_bam.path.replace(/^.*[\\\/]/, "").replace(/\.[^/.]+$/, "") + ".spp.narrowPeak")
+  - id: output_spp_region_peak
+    type: ['null', File]
+    description: "regionPeak output file"
+    outputBinding:
+      glob: $(inputs.input_bam.path.replace(/^.*[\\\/]/, "").replace(/\.[^/.]+$/, "") + ".spp.regionPeak")
+  - id: output_spp_rdata
+    type: ['null', File]
+    description: "Rdata file from the run_spp.R run"
+    outputBinding:
+      glob: $(inputs.input_bam.path.replace(/^.*[\\\/]/, "").replace(/\.[^/.]+$/, "") + ".spp.Rdata")
+
+baseCommand: run_spp.R
+arguments:
+  - valueFrom: $("-out=" + inputs.input_bam.path.replace(/^.*[\\\/]/, "").replace(/\.[^/.]+$/, "") + ".spp_cross_corr.txt")


### PR DESCRIPTION
This CWL tool wraps a wrapper script run_spp.R (https://github.com/crazyhottommy/phantompeakqualtools) which executes the R package SPP (https://github.com/hms-dbmi/spp). It is specifically designed for the analysis of Chip-Seq data from Illumina. 

Quoting the phantompeakqualtools website, one typically usage of this package is:
> Determine strand cross-correlation peak / predominant fragment length OR print out quality measures