### PR TITLE
add simple kallisto wrappers and workflow

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
   - pip install setuptools==18.5
   - pip install html5lib
   - pip install cwltool
-  - pip install cwl-runner
+  - pip install cwlref-runner
 
 services:
   - docker

--- a/tools/kallisto-index.cwl
+++ b/tools/kallisto-index.cwl
@@ -10,17 +10,11 @@ inputs:
  fasta-files:
    type: File[]
    format: http://edamontology.org/format_1929 # FASTA
-   doc: 
-   inputBinding:
-    position: 100
-
- index_name:
-   type: string?
-   default: index.idx
-   inputBinding:
-     prefix: "--index"
+   inputBinding: {}
 
 baseCommand: [ kallisto, index ]
+
+arguments: [ --index, index.idx ]
 
 outputs:
  index:

--- a/tools/kallisto-index.cwl
+++ b/tools/kallisto-index.cwl
@@ -1,0 +1,30 @@
+#!/usr/bin/env cwl-runner
+cwlVersion: v1.0
+class: CommandLineTool
+
+hints:
+ DockerRequirement:
+  dockerPull: insilicodb/kallisto
+
+inputs:
+ fasta-files:
+   type: File[]
+   format: http://edamontology.org/format_1929 # FASTA
+   doc: 
+   inputBinding:
+    position: 100
+
+ index_name:
+   type: string?
+   default: index.idx
+   inputBinding:
+     prefix: "--index"
+
+baseCommand: [ kallisto, index ]
+
+outputs:
+ index:
+  type: File
+  outputBinding:
+   glob: $(inputs.index_name)
+   

--- a/tools/kallisto-quant.cwl
+++ b/tools/kallisto-quant.cwl
@@ -10,8 +10,7 @@ inputs:
  fastqs:
    type: File[]
    format: http://edamontology.org/format_1930 # FASTA
-   inputBinding:
-    position: 100
+   inputBinding: {}
 
  index:
    type: File
@@ -19,6 +18,7 @@ inputs:
      prefix: "--index"
 
 baseCommand: [ kallisto, quant ]
+
 arguments: [ "--output-dir", out ]
 
 outputs:

--- a/tools/kallisto-quant.cwl
+++ b/tools/kallisto-quant.cwl
@@ -1,0 +1,29 @@
+#!/usr/bin/env cwl-runner
+cwlVersion: v1.0
+class: CommandLineTool
+
+hints:
+ DockerRequirement:
+  dockerPull: insilicodb/kallisto
+
+inputs:
+ fastqs:
+   type: File[]
+   format: http://edamontology.org/format_1930 # FASTA
+   inputBinding:
+    position: 100
+
+ index:
+   type: File
+   inputBinding:
+     prefix: "--index"
+
+baseCommand: [ kallisto, quant ]
+arguments: [ "--output-dir", out ]
+
+outputs:
+ quantification:
+  type: File
+  outputBinding:
+   glob: out/abundance.h5
+   

--- a/workflows/kallisto-demo.cwl
+++ b/workflows/kallisto-demo.cwl
@@ -1,0 +1,36 @@
+#!/usr/bin/env cwl-runner
+cwlVersion: v1.0
+class: Workflow
+
+# Inspired by
+# https://github.com/InSilicoDB/pipeline-kallisto/blob/develop/main.nf
+
+hints:
+ DockerRequirement:
+  dockerPull: insilicodb/kallisto
+
+inputs:
+  transcripts: File[]
+  reads: File[]
+
+steps:
+  indexing:
+    run: ../tools/kallisto-index.cwl
+    in:
+      fasta-files: transcripts
+    out:
+     - index
+  quantifying:
+    run: ../tools/kallisto-quant.cwl
+    in:
+      index: indexing/index
+      fastqs: reads
+    out:
+      - quantification
+
+outputs:
+  quants:
+    type: File
+    outputSource: quantifying/quantification
+
+


### PR DESCRIPTION
For @alaincoletta

Inspired by
https://github.com/InSilicoDB/pipeline-kallisto/blob/develop/main.nf

To run:

```
git clone https://github.com/common-workflow-language/workflows.git --branch kallisto
virtualenv cwl
source cwl/bin/activate
pip install cwlref-runner
cd workflows/workflows
# download your data
cwl-runner kallisto-demo.cwl --transcripts path/to/transcripts.fasta --reads path/to/first-reads.fastq --reads path/to/second-reads.fastq
# verify the output
ls -l abundance.h5
```
