### PR TITLE
[FOLLOW-UP] Apply Custom Type to VALIDATION_STRINGENCY in Picard

### DIFF
--- a/tools/picard-MarkDuplicates.cwl
+++ b/tools/picard-MarkDuplicates.cwl
@@ -53,6 +53,9 @@ dct:creator:
 requirements:
 - $import: picard-docker.yml
 - class: InlineJavascriptRequirement
+- class: SchemaDefRequirement
+  types:
+    - $import: picard-validation-stringency.yml
 
 inputs:
   comment:
@@ -92,7 +95,7 @@ inputs:
       says otherwise. Default value false. This option can be set to 'null' to clear
       the default value. Possible values {true, false}
   validationStringency:
-    type: string?
+    type: picard-validation-stringency.yml#VALIDATION_STRINGENCY?
     inputBinding:
       position: 23
       prefix: VALIDATION_STRINGENCY=

--- a/tools/picard-validation-stringency.yml
+++ b/tools/picard-validation-stringency.yml
@@ -1,0 +1,3 @@
+type: enum
+name: VALIDATION_STRINGENCY
+symbols: [ 'STRICT', 'LENIENT', 'SILENT' ]


### PR DESCRIPTION
This PR uses `Enum` to represent the valid values to `VALIDATION_STRINGENCY` for additional clarity.