### PR TITLE
Modifications to trimmomatic and STAR

### DIFF
--- a/tools/STAR.cwl
+++ b/tools/STAR.cwl
@@ -1256,7 +1256,7 @@ inputs:
       int: -1 to 10  BAM compression level, -1=default compression (6?), 0=no
       compression, 10=maximum compression
   limitBAMsortRAM:
-    type: int?
+    type: long?
     inputBinding:
       position: 1
       prefix: --limitBAMsortRAM
@@ -1379,6 +1379,17 @@ outputs:
             return null;
           var p=inputs.outFileNamePrefix?inputs.outFileNamePrefix:"";
           return p+"Aligned.toTranscriptome.out.bam";
+        }
+
+  bamRemDups:
+    type: File?
+    outputBinding:
+      glob: |
+        ${
+          if (inputs.bamRemoveDuplicatesType != "UniqueIdentical")
+            return null;
+          var p=inputs.outFileNamePrefix?inputs.outFileNamePrefix:"";
+          return p+"Processed.out.bam";
         }
 
 baseCommand: [STAR]

--- a/tools/bowtie.cwl
+++ b/tools/bowtie.cwl
@@ -473,7 +473,7 @@ outputs:
   output_bowtie_log:
     type: File
     outputBinding:
-      glob: $(inputs.filename + '.log’)
+      glob: $(inputs.filename + '.log')
 
 baseCommand:
 - bowtie

--- a/tools/trimmomatic-illumina_clipping.yaml
+++ b/tools/trimmomatic-illumina_clipping.yaml
@@ -30,7 +30,7 @@ fields:
       mode has a very low false positive rate, this can be safely reduced, even
       down to 1, to allow shorter adapter fragments to be removed.
   - name: keepBothReads
-    type: boolean
+    type: boolean?
     doc: |
       After read-though has been detected by palindrome mode, and the adapter
       sequence removed, the reverse read contains the same sequence information

--- a/tools/trimmomatic.cwl
+++ b/tools/trimmomatic.cwl
@@ -121,15 +121,23 @@ inputs:
     type: trimmomatic-illumina_clipping.yaml#illuminaClipping?
     inputBinding:
       valueFrom: |
-        ${ if ( self ) {
-             return "ILLUMINACLIP:" + inputs.illuminaClip.adapters.path + ":"
-               + self.seedMismatches + ":" + self.palindromeClipThreshold + ":"
-               + self.simpleClipThreshold + ":" + self.minAdapterLength + ":"
-               + self.keepBothReads;
-           } else {
-             return self;
-           }
-         }
+        ${ if ( self ) { 
+            var i="ILLUMINACLIP:" + inputs.illuminaClip.adapters.path + ":"
+              + self.seedMismatches + ":" + self.palindromeClipThreshold + ":"
+              + self.simpleClipThreshold;
+            if ( self.minAdapterLength && !self.keepBothReads ) {
+              return i + ":" + self.minAdapterLength;
+            } else if ( self.minAdapterLength && self.keepBothReads ) {
+              return i + ":" + self.minAdapterLength + ":" + self.keepBothReads;
+            } else if ( self.keepBothReads && !self.minAdapterLength ) {
+              return i + ":8:" + self.keepBothReads;
+            } else {
+              return i;
+            }
+          } else {
+            return self;
+          }
+        }
       position: 11
     doc: Cut adapter and other illumina-specific sequences from the read.
 

--- a/tools/trimmomatic.cwl
+++ b/tools/trimmomatic.cwl
@@ -235,7 +235,7 @@ outputs:
     type: File?
     format: edam:format_1930  # fastq
     outputBinding:
-      glob: $(inputs.reads1.nameroot).unpaired.trimmed.fastq
+      glob: $(inputs.reads1.nameroot).trimmed.unpaired.fastq
 
   reads2_trimmed_paired:
     type: File?
@@ -255,7 +255,7 @@ outputs:
     outputBinding:
       glob: |
         ${ if (inputs.reads2 ) {
-             return inputs.reads2.nameroot + '.unpaired.trimmed.fastq';
+             return inputs.reads2.nameroot + '.trimmed.unpaired.fastq';
            } else {
              return null;
            }


### PR DESCRIPTION
Corrected the following errors in these tools:

1. trimmomatic.cwl did not collect paired-end trimmed-unpaired outputs due to file names being incorrect

2. trimmomatic-illumina_clipping.yaml had only one optional input specified as optional. When keepBothReads is given, but minAdapterLength is not, it places a `null` value in the argument that doesn't work. Updated this and main trimmomatic.cwl documents to work with optional inputs per the trimmomatic manual. Alternatively instead of optional inputs & the many if else statements I placed in there you could set default values (minAdapterLength: 8 and keepBothReads: false). Not sure which is more acceptable, but the edits I've made work on my end. 

3. STAR did not have an output field for the marking duplicates in a bam option (--bamRemoveDuplicatesType) and did not run when --limitBAMsortRAM was a long int for larger memory requests. 