### PR TITLE
Change the Pitagora-CWL repository URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ terms and conditions of the Apache License version 2.0 (see LICENSE.txt).
 * https://github.com/Duke-GCB/GGR-cwl
 * https://github.com/jorvis/FALCON/tree/master/cwl/tools
 * https://github.com/h3abionet/h3abionet16S/tree/master/workflows-cwl
-* https://github.com/pitagora-galaxy/cwl
+* https://github.com/pitagora-network/pitagora-cwl
 * https://github.com/h3abionet/h3agatk
 * https://dockstore.org/
 


### PR DESCRIPTION
Our CWL tools and workflows at [pitagora-galaxy/cwl](https://github.com/pitagora-network/pitagora-cwl) have moved to [pitagora-network/pitagora-cwl](https://github.com/pitagora-network/pitagora-cwl). Cloning our repo will no longer create another `cwl` directory 😉 